### PR TITLE
[ci] GitHub Actions에 테스트 결과 리포트 및 커버리지 분석 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
@@ -35,6 +35,39 @@ jobs:
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build
+
+    - name: Run Tests and Generate Reports
+      run: |
+        ./gradlew test --continue
+        ./gradlew jacocoTestReport
+
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results
+        path: |
+          build/reports/tests/test/
+          build/test-results/test/
+        retention-days: 30
+
+    - name: Upload Coverage Reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: coverage-reports
+        path: |
+          build/reports/jacoco/test/
+        retention-days: 30
+
+    - name: Publish Test Report
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        name: Gradle Tests
+        path: build/test-results/test/*.xml
+        reporter: java-junit
+        fail-on-error: true
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
@@ -55,7 +88,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         java-version: '21'

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### personal ###
+/CLAUDE.md
+/**.ipynb
+/.claude/settings.local.json

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.springframework.boot' version '3.4.8'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.jetbrains.kotlin.plugin.jpa' version '1.9.25'
+    id 'jacoco'
 }
 
 group = 'autocat'
@@ -46,4 +47,24 @@ allOpen {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.80
+            }
+        }
+    }
 }

--- a/src/main/kotlin/autocat/sample/domain/Member.kt
+++ b/src/main/kotlin/autocat/sample/domain/Member.kt
@@ -57,7 +57,7 @@ open class Member(
 
     private fun changeNickname(newNicnkame: String){
         validateNickname(newNicnkame)
-        this@Member.nickname = newNicnkame
+        nickname = newNicnkame
     }
 
     private fun changeEmail(newEmail: String){
@@ -76,8 +76,8 @@ open class Member(
     }
 
     fun update(request: MemberUpdateRequest) {
-        request.nickname?.takeIf { it.isNotBlank() }?.let { changeNickname(it) }
-        request.email?.takeIf { it.isNotBlank() }?.let { changeEmail(it) }
+        request.nickname?.let { changeNickname(it) }
+        request.email?.let { changeEmail(it) }
 
     }
 

--- a/src/test/kotlin/autocat/sample/domain/MemberTest.kt
+++ b/src/test/kotlin/autocat/sample/domain/MemberTest.kt
@@ -1,15 +1,12 @@
 package autocat.sample.domain
 
-import autocat.sample.repository.MemberRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.data.repository.findByIdOrNull
 
 @DataJpaTest(showSql = true)
 @DisplayName("Member 도메인 테스트")
@@ -25,8 +22,8 @@ class MemberTest() {
     }
 
     @Nested
-    @DisplayName("Member 생성 및 저장")
-    inner class MemberCreationAndPersistence {
+    @DisplayName("Member 생성")
+    inner class MemberCreation {
 
         @Test
         @DisplayName("Member를 생성할 수 있다")
@@ -36,6 +33,7 @@ class MemberTest() {
 
             // then
             with(member) {
+                assertThat(id).isNull()
                 assertThat(nickname).isEqualTo(MemberFixture.createMemberRegisterRequest().nickname)
                 assertThat(email).isEqualTo(MemberFixture.createMemberRegisterRequest().email)
                 assertThat(status).isEqualTo(MemberStatus.PENDING)
@@ -44,12 +42,12 @@ class MemberTest() {
     }
 
     @Nested
-    @DisplayName("닉네임 변경")
-    inner class ChangeNickname {
+    @DisplayName("업데이트")
+    inner class MemberUpdate {
 
         @Test
         @DisplayName("유효한 닉네임으로 변경할 수 있다")
-        fun `should change nickname with valid input`() {
+        fun `should update nickname with valid input`() {
             // given
             val newNickname = "newNickname"
             val updateRequest = MemberUpdateRequest(newNickname, "donghyeond@gmail.com")
@@ -61,53 +59,9 @@ class MemberTest() {
             assertThat(member.nickname).isEqualTo(updateRequest.nickname)
         }
 
-//        @Test
-//        @DisplayName("빈 닉네임으로 변경 시 예외가 발생한다")
-//        fun `should throw exception when changing to blank nickname`() {
-//            // given
-//            val blacnkNickname = ""
-//            val updateRequest = MemberUpdateRequest(blacnkNickname, "donghyeond@gmail.com")
-//
-//            // when & then
-//            assertThatThrownBy { member.update(updateRequest) }
-//                .isInstanceOf(IllegalArgumentException::class.java)
-//                .hasMessage("nickname cannot be blank")
-//        }
-//
-//        @Test
-//        @DisplayName("공백만 있는 닉네임으로 변경 시 예외가 발생한다")
-//        fun `should throw exception when changing to whitespace nickname`() {
-//            // given
-//            val whitespaceNickname = " "
-//            val updateRequest = MemberUpdateRequest(whitespaceNickname, "donghyeond@gmail.com")
-//
-//            // when & then
-//            assertThatThrownBy { member.update(updateRequest) }
-//                .isInstanceOf(IllegalArgumentException::class.java)
-//                .hasMessage("nickname cannot be blank")
-//        }
-//
-//        @Test
-//        @DisplayName("20자를 초과하는 닉네임으로 업데이트시 예외가 발생한다")
-//        fun `should throw exception when creating with nickname longer than 20 characters`() {
-//            // given
-//            val longNickname = "a".repeat(21)
-//            val updateRequest = MemberUpdateRequest(longNickname, "dongheond@gmail.com")
-//
-//            // when & then
-//            assertThatThrownBy { member.update(updateRequest) }
-//                .isInstanceOf(IllegalArgumentException::class.java)
-//                .hasMessage("nickname must be 20 characters or less")
-//        }
-    }
-
-    @Nested
-    @DisplayName("이메일 변경")
-    inner class ChangeEmail {
-
         @Test
         @DisplayName("유효한 이메일로 변경할 수 있다")
-        fun `should change email with valid input`() {
+        fun `should update email with valid input`() {
             // given
             val newEmail = "newemail@test.com"
             val updateRequest = MemberUpdateRequest("autoacat", newEmail)
@@ -119,31 +73,103 @@ class MemberTest() {
             assertThat(member.email).isEqualTo(newEmail)
         }
 
-//        @Test
-//        @DisplayName("빈 이메일로 변경 시 예외가 발생한다")
-//        fun `should throw exception when changing to blank email`() {
-//            // given
-//            val blankEmail = ""
-//            val updateRequest = MemberUpdateRequest("autoacat", blankEmail)
-//
-//            // when & then
-//            assertThatThrownBy { member.update(updateRequest) }
-//                .isInstanceOf(IllegalArgumentException::class.java)
-//                .hasMessage("email cannot be blank")
-//        }
-//
-//        @Test
-//        @DisplayName("@가 없는 이메일로 변경 시 예외가 발생한다")
-//        fun `should throw exception when changing to invalid email format`() {
-//            // given
-//            val invalidEmail = "invalidemail"
-//            val updateRequest = MemberUpdateRequest("autoacat", invalidEmail)
-//
-//            // when & then
-//            assertThatThrownBy { member.update(updateRequest) }
-//                .isInstanceOf(IllegalArgumentException::class.java)
-//                .hasMessage("email must be valid format")
-//        }
+        @Test
+        @DisplayName("유효한 이메일과 닉네임으로 변경할 수 있다")
+        fun `should update with valid input`() {
+            // given
+            val updateRequest = MemberUpdateRequest("new autoacat", "newdonghyeon@gmail.new")
+
+            // when
+            member.update(updateRequest)
+
+            // then
+            with(member) {
+                assertThat(email).isEqualTo(updateRequest.email)
+                assertThat(nickname).isEqualTo(updateRequest.nickname)
+            }
+        }
+
+        @Test
+        @DisplayName("빈 닉네임으로 변경 시 예외가 발생한다")
+        fun `should throw exception when updating to blank nickname`() {
+            // given
+            val blacnkNickname = ""
+            val updateRequest = MemberUpdateRequest(blacnkNickname, "donghyeond@gmail.com")
+
+            // when & then
+            assertThatThrownBy { member.update(updateRequest) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("nickname cannot be blank")
+        }
+
+        @Test
+        @DisplayName("공백만 있는 닉네임으로 변경 시 예외가 발생한다")
+        fun `should throw exception when updating to whitespace nickname`() {
+            // given
+            val whitespaceNickname = " "
+            val updateRequest = MemberUpdateRequest(whitespaceNickname, "donghyeond@gmail.com")
+
+            // when & then
+            assertThatThrownBy { member.update(updateRequest) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("nickname cannot be blank")
+        }
+
+        @Test
+        @DisplayName("20자를 초과하는 닉네임으로 업데이트시 예외가 발생한다")
+        fun `should throw exception when updating with nickname longer than 20 characters`() {
+            // given
+            val longNickname = "a".repeat(21)
+            val updateRequest = MemberUpdateRequest(longNickname, "dongheond@gmail.com")
+
+            // when & then
+            assertThatThrownBy { member.update(updateRequest) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("nickname must be 20 characters or less")
+        }
+
+        @Test
+        @DisplayName("빈 이메일로 변경 시 예외가 발생한다")
+        fun `should throw exception when changing to blank email`() {
+            // given
+            val blankEmail = ""
+            val updateRequest = MemberUpdateRequest("autoacat", blankEmail)
+
+            // when & then
+            assertThatThrownBy { member.update(updateRequest) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("email cannot be blank")
+        }
+
+        @Test
+        @DisplayName("@가 없는 이메일로 변경 시 예외가 발생한다")
+        fun `should throw exception when changing to invalid email format`() {
+            // given
+            val invalidEmail = "invalidemail"
+            val updateRequest = MemberUpdateRequest("autoacat", invalidEmail)
+
+            // when & then
+            assertThatThrownBy { member.update(updateRequest) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("email must be valid format")
+        }
+
+        @Test
+        @DisplayName("null 필드로 업데이트 시 업데이트가 일어나지 않는다")
+        fun `should not update when updating with null fields`() {
+            // given
+            val created = MemberFixture.create()
+            val updateRequest = MemberUpdateRequest(null, null)
+
+            // when
+            created.update(updateRequest)
+
+            // then
+            with(created) {
+                assertThat(nickname).isEqualTo(MemberFixture.createMemberRegisterRequest().nickname).isNotNull()
+                assertThat(email).isEqualTo(MemberFixture.createMemberRegisterRequest().email).isNotNull()
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
- GitHub Actions 워크플로우에 테스트 실행 및 아티팩트 업로드 기능 추가
- Jacoco 플러그인을 통한 코드 커버리지 리포트 생성 설정 (최소 80% 검증)
- JDK 버전을 17에서 21로 통일
- 테스트 결과를 XML/HTML 형태로 30일간 보관하도록 설정
- Member 도메인 update 로직 간소화 및 테스트 케이스 확장
